### PR TITLE
Update the conference name for "Understanding and Improving Fast AT"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Anyone is welcomed to submit a pull request for the related and unlisted papers 
 
 <a id='General_training'></a>
 ## General Defenses (training phase)
-* [Understanding and Improving Fast Adversarial Training](https://arxiv.org/pdf/2007.02617.pdf) <br/> A systematic study of catastrophic overfitting in adversarial training, its reasons, and ways of resolving it. The proposed regularizer, *GradAlign*, helps to prevent catastrophic overfitting and scale FGSM training to high Linf-perturbations.
+* [Understanding and Improving Fast Adversarial Training](https://arxiv.org/pdf/2007.02617.pdf) (NeurIPS 2020) <br/> A systematic study of catastrophic overfitting in adversarial training, its reasons, and ways of resolving it. The proposed regularizer, *GradAlign*, helps to prevent catastrophic overfitting and scale FGSM training to high Linf-perturbations.
 
 * [Smooth Adversarial Training](https://arxiv.org/pdf/2006.14536.pdf) <br/> This paper advocate using smooth variants of ReLU during adversarial training, which can achieve state-of-the-art performance on ImageNet.  
 


### PR DESCRIPTION
Just a small update about the conference acceptance for "Understanding and Improving Fast Adversarial Training".

Thanks!