### PR TITLE
Robust Models are less Over-Confident

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ data and (poorly) trained models, namely, learned representations.
 
 <a id='Beyond_Safety'></a>
 ## Beyond Safety
+* [Robust Models are less Over-Confident](https://openreview.net/forum?id=5K3uopkizS) (NeurIPS 2022) <br/> This paper analyzes the (over)confidence of robust CNNs and concludes that robust models that are significantly less overconfident with their decisions, even on clean data. Further, the authors provide a model zoo of various CNNs trained with and without adversarial defenses.
+
 * [Improved Autoregressive Modeling with Distribution Smoothing](https://openreview.net/forum?id=rJA5Pz7lHKb) (ICLR 2021) <br/> This paper apply similar idea of randomized smoothing into autoregressive generative modeling, which first modeling a smoothed data distribution and then denoise the sampled data.
 
 * [Defending Against Image Corruptions Through Adversarial Augmentations](https://arxiv.org/pdf/2104.01086.pdf) <br/> This paper proposes AdversarialAugment method to adversarially craft corrupted augmented images during training.


### PR DESCRIPTION
And finally, a NeurIPS 2022 paper that analyzes the (over)confidence of robust vs normal models.
I put it in "Beyond safety", though it could also be seen as an empirical analysis.

We also host a model zoo (part of the paper), of RobustBench models retrained without adversarial defenses which may be of interest to readers that want to perform side-by-side comparisons as we did.